### PR TITLE
Misc changes

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -51,8 +51,7 @@ or, in your Gemfile
       protect_from_forgery :except => [:bank_callback]
 
       def bank_callback
-        @system_pay = SystemPay.new(params)
-        if @system_pay.valid_signature?(params[:signature])
+        if SystemPay.valid_signature?(params)
         
           order_transaction = OrderTransaction.find_by_reference params[:reference], :last
           order = order_transaction.order

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -22,13 +22,13 @@ or, in your Gemfile
 
 ### in development.rb :
 
-    # Your test certificat
-    SystemPay.certificat = '9123456299120752'	
+    # Your test certificate
+    SystemPay.certificate = '9123456299120752'	
   
 ### in production.rb :
 
-    # Your production certificat
-    SystemPay.certificat = '7193156219823756'	
+    # Your production certificate
+    SystemPay.certificate = '7193156219823756'	
     # Set the production mode
     SystemPay.vads_ctx_mode = 'PRODUCTION'	    
 

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -37,7 +37,7 @@ class SystemPay
   
   attr_accessor :vads_amount, :vads_available_languages, :vads_capture_delay, :vads_contracts, :vads_currency, :vads_cust_address, :vads_cust_cell_phone, 
   :vads_cust_email, :vads_cust_id, :vads_cust_name, :vads_redirect_error_message, :vads_redirect_success_message, :vads_trans_date, :vads_trans_id, :vads_url_cancel, :vads_url_error, 
-  :vads_url_referral, :vads_url_refused, :vads_url_success
+  :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode
 
   # Public: Creation of new instance.
   #         

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -67,6 +67,8 @@ class SystemPay
     @vads_trans_date ||= Time.now.utc.strftime("%Y%m%d%H%M%S")
     @vads_trans_id = @vads_trans_id.to_s.rjust(6, '0')
     
+    raise ArgumentError.new("Invalid trans_id: #{@vads_trans_id.inspect}") unless @vads_trans_id =~ /\A[0-8][0-9]{5}\Z/
+    
   end
 
   # Public: Perform the signature of the request based on the parameters

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -35,6 +35,12 @@ class SystemPay
   @@certificate = '1122334455667788'
   cattr_accessor :certificate
   
+  # Backward compatibility
+  class << self
+    alias_method :certificat, :certificate
+    alias_method :certificat=, :certificate=
+  end
+  
   attr_accessor :vads_amount, :vads_available_languages, :vads_capture_delay, :vads_contracts, :vads_currency, :vads_cust_address, :vads_cust_cell_phone, 
   :vads_cust_email, :vads_cust_id, :vads_cust_name, :vads_redirect_error_message, :vads_redirect_success_message, :vads_trans_date, :vads_trans_id, :vads_url_cancel, :vads_url_error, 
   :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -43,7 +43,7 @@ class SystemPay
   
   attr_accessor :vads_amount, :vads_available_languages, :vads_capture_delay, :vads_contracts, :vads_currency, :vads_cust_address, :vads_cust_cell_phone, 
   :vads_cust_email, :vads_cust_id, :vads_cust_name, :vads_redirect_error_message, :vads_redirect_success_message, :vads_trans_date, :vads_trans_id, :vads_url_cancel, :vads_url_error, 
-  :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode
+  :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode, :vads_language
 
   # Public: Creation of new instance.
   #         

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -104,7 +104,13 @@ class SystemPay
   end
   
   def sorted_array
-    (instance_variables_array + self.class.class_variables_array).uniq.sort
+    class_variables_hash = Hash[*self.class.class_variables_array.flatten(1)]
+    instance_variables_hash = Hash[*instance_variables_array.flatten(1)]
+    
+    names = (class_variables_hash.keys + instance_variables_hash.keys).uniq.sort
+    names.map do |name|
+      [name, instance_variables_hash[name] || class_variables_hash[name]]
+    end
   end
   
   def sorted_values

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -43,7 +43,7 @@ class SystemPay
   
   attr_accessor :vads_amount, :vads_available_languages, :vads_capture_delay, :vads_contracts, :vads_currency, :vads_cust_address, :vads_cust_cell_phone, 
   :vads_cust_email, :vads_cust_id, :vads_cust_name, :vads_redirect_error_message, :vads_redirect_success_message, :vads_trans_date, :vads_trans_id, :vads_url_cancel, :vads_url_error, 
-  :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode, :vads_language
+  :vads_url_referral, :vads_url_refused, :vads_url_success, :vads_return_mode, :vads_language, :vads_order_id, :vads_shop_name, :vads_shop_url
 
   # Public: Creation of new instance.
   #         

--- a/lib/system_pay.rb
+++ b/lib/system_pay.rb
@@ -32,8 +32,8 @@ class SystemPay
   @@vads_version = 'V2'
   cattr_accessor :vads_version
   
-  @@certificat = '1122334455667788'
-  cattr_accessor :certificat  
+  @@certificate = '1122334455667788'
+  cattr_accessor :certificate
   
   attr_accessor :vads_amount, :vads_available_languages, :vads_capture_delay, :vads_contracts, :vads_currency, :vads_cust_address, :vads_cust_cell_phone, 
   :vads_cust_email, :vads_cust_id, :vads_cust_name, :vads_redirect_error_message, :vads_redirect_success_message, :vads_trans_date, :vads_trans_id, :vads_url_cancel, :vads_url_error, 
@@ -92,7 +92,7 @@ class SystemPay
   private
 
   def self.sign(values)
-    Digest::SHA1.hexdigest((values+[certificat]).join("+"))
+    Digest::SHA1.hexdigest((values+[certificate]).join("+"))
   end   
   
   def instance_variables_array


### PR DESCRIPTION
- Verifiy `trans_id` validity
- Renamed `certificat` to `certificate` (with backward compatibility)
- Added missing `vads_return_mode` instance variable
- Fixed incorrect handling of overriden values in instance methods (for example if a value was both in class and instance attributes, it appeared twice in the `sorted_array`)
