### PR TITLE
Added ERB tag support when loading system_pay.yml

### DIFF
--- a/lib/system_pay/railtie.rb
+++ b/lib/system_pay/railtie.rb
@@ -5,11 +5,11 @@ require 'rails'
 module SystemPay
   class Railtie < ::Rails::Railtie
     initializer "system_pay.form_helper" do
-      ActiveSupport.on_load(:action_controller) do 
+      ActiveSupport.on_load(:action_controller) do
         helper SystemPay::FormHelper
       end
 
-=begin      
+=begin
       config.to_prepare do
         self.setup! # &method(:activate).to_proc
       end
@@ -17,7 +17,7 @@ module SystemPay
 
       system_pay_config_file = File.join(Rails.root,'config','system_pay.yml')
       raise "#{system_pay_config_file} is missing!" unless File.exists? system_pay_config_file
-      system_pay_config = YAML.load_file(system_pay_config_file)[Rails.env].symbolize_keys
+      system_pay_config = YAML.load(ERB.new(IO.read(system_pay_config_file)).result)[Rails.env].symbolize_keys
 
       system_pay_config.each_pair do |n, v|
         SystemPay::Vads.class_variable_set("@@#{n}", v)


### PR DESCRIPTION
I modified the YAML file loader to allow ERB tags. The purpose is to allow parameterization through environment variables.

Example for `vads_site_id` :

```
# Environment variable
SYSTEM_PAY_SITE_ID = "12345678"

# config/system_pay.yml
vads_site_id: <%= ENV["SYSTEM_PAY_SITE_ID"] %>
```
